### PR TITLE
Add basic assertions

### DIFF
--- a/src/galvanize/assertion.gleam
+++ b/src/galvanize/assertion.gleam
@@ -1,0 +1,41 @@
+/// Describes the result of a single test's comparison.
+///
+pub opaque type Assertion {
+  Pass
+  Fail(Reason)
+}
+
+/// The reason why an assertion failed.
+///
+pub type Reason {
+  EqualityAssertionFailed(expected: String, actual: String)
+  AssertionFailed(subject: String, asserted: String, object: String)
+  GenericFailure(reason: String)
+}
+
+/// Turns an assertion into a `Result`.
+///
+pub fn to_result(assertion: Assertion) -> Result(Nil, Reason) {
+  case assertion {
+    Pass -> Ok(Nil)
+    Fail(reason) -> Error(reason)
+  }
+}
+
+/// An assertion that never fails.
+///
+pub fn pass() -> Assertion {
+  Pass
+}
+
+/// A shorthand equivalent to `fail_with_reason(GenericFailure(reason))`.
+///
+pub fn fail(with reason: String) -> Assertion {
+  Fail(GenericFailure(reason))
+}
+
+/// Create an assertion that always fails with the given reason.
+///
+pub fn fail_with_reason(with reason: Reason) -> Assertion {
+  Fail(reason)
+}

--- a/src/galvanize/assertion.gleam
+++ b/src/galvanize/assertion.gleam
@@ -22,7 +22,35 @@ pub fn to_result(assertion: Assertion) -> Result(Nil, Reason) {
   }
 }
 
+/// Returns `True` if the assertion has failed.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > 1 |> should.be_equal(to: 1) |> has_failed
+/// False
+/// ```
+///
+/// ```gleam
+/// > 1 |> should.differ(from: 1) |> has_failed
+/// True
+/// ```
+///
+pub fn has_failed(assertion: Assertion) -> Bool {
+  case assertion {
+    Pass -> False
+    Fail(_) -> True
+  }
+}
+
 /// An assertion that never fails.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > pass() |> has_failed
+/// False
+/// ```
 ///
 pub fn pass() -> Assertion {
   Pass
@@ -30,11 +58,27 @@ pub fn pass() -> Assertion {
 
 /// A shorthand equivalent to `fail_with_reason(GenericFailure(reason))`.
 ///
+/// ## Examples
+///
+/// ```gleam
+/// > fail(with: "always fails") |> to_result
+/// Error(GenericFailure("always fails"))
+/// ```
+///
 pub fn fail(with reason: String) -> Assertion {
   Fail(GenericFailure(reason))
 }
 
 /// Create an assertion that always fails with the given reason.
+/// It is recommended to only use this function if the preexisting
+/// assertions in the `galvanize/should` module do not fit your needs.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > fail_with_reason(EqualityAssertionFailed("1", "2")) |> to_result
+/// Error(EqualityAssertionFailed("1", "2"))
+/// ```
 ///
 pub fn fail_with_reason(with reason: Reason) -> Assertion {
   Fail(reason)

--- a/src/galvanize/should.gleam
+++ b/src/galvanize/should.gleam
@@ -1,22 +1,247 @@
-import gleam/list
+//// Assertions are the basic building blocks of tests: any test
+//// suite is comprised of one or more assertions that can be grouped
+//// together:
+////
+//// ```gleam
+//// TODO: add example of a couple assertions in a test
+////       once we decide on an interface
+//// ```
+////
+//// This module exposes some basic functions used to make assertions
+//// and combine them.
+//// 
 
-pub fn equal(input: a, expected: a) -> Nil {
-  case input == expected {
-    True -> Nil
-    False -> panic
+import galvanize/assertion.{Assertion}
+import gleam/string
+import gleam/int
+
+/// An assertion that passes if the arguments are equal.
+///
+/// ## Examples
+///
+/// ```gleam
+/// import gleam.list
+///
+/// ["a", "b", "c"]
+/// |> list.length
+/// |> equal(3)
+/// // This assertion passes.
+/// ```
+///
+/// ```gleam
+/// Ok(1)
+/// |> equal(Error("a"))
+/// // This assertion fails.
+/// ```
+///
+pub fn equal(actual: a, expected: a) -> Assertion {
+  // TODO: for now in case of equality failure the only reason is `Equality`
+  // At the end it will just show the two strings side by side (maybe even
+  // with sime kind of super simple diff).
+  // However, it could be nice to show more useful diffs for some special
+  // types like sets and maps to just highlight the diffing elements.
+  //
+  // This could be achieved in two ways that I can think of:
+  // - making other specialized functions `equal_set`, `equal_map`, ...
+  //   that can handle the diffing and report different failure reasons
+  //   with more detail for the test runner to show
+  // - keeping a single `should.equal` (maybe better in terms of DX)
+  //   and use an ugly hack inside: turn the compared data into a dynamic,
+  //   inspect its type with `inspect` and use the appropriate reason based
+  //   on that defaulting to the `Equality` reason for anything that does
+  //   not require nothing more than a simple diff.
+  case actual == expected {
+    True -> assertion.pass()
+    False ->
+      assertion.fail_with_reason(assertion.EqualityAssertionFailed(
+        actual: string.inspect(actual),
+        expected: string.inspect(expected),
+      ))
   }
 }
 
-pub fn not_equal(input: a, expected: a) -> Nil {
-  case input == expected {
-    True -> panic
-    False -> Nil
+/// An assertion that passes if the arguments are not equal.
+///
+/// ## Examples
+///
+/// ```gleam
+/// import gleam.list
+///
+/// ["a", "b", "c"]
+/// |> list.length
+/// |> not_equal(2)
+/// // This assertion passes.
+/// ```
+///
+/// ```gleam
+/// Ok(1)
+/// |> not_equal(Ok(1))
+/// // This assertion fails.
+/// ```
+///
+pub fn not_equal(one: a, other: a) -> Assertion {
+  case one != other {
+    True -> assertion.pass()
+    False ->
+      assertion.fail_with_reason(assertion.AssertionFailed(
+        string.inspect(one),
+        "should not equal",
+        string.inspect(other),
+      ))
   }
 }
 
-pub fn be_in(input: a, expected: List(a)) -> Nil {
-  case list.contains(expected, input) {
-    True -> Nil
-    False -> panic
+/// An assertion that passes if its argument is `Ok(_)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// Ok(1) |> be_ok
+/// // This assertion passes.
+/// ```
+///
+/// ```gleam
+/// Error("a") |> be_ok
+/// // This assertion fails.
+/// ```
+///
+pub fn be_ok(value: Result(a, e)) -> Assertion {
+  case value {
+    Ok(_) -> assertion.pass()
+    Error(_) ->
+      assertion.fail_with_reason(assertion.AssertionFailed(
+        string.inspect(value),
+        "should be",
+        "Ok(_)",
+      ))
+  }
+}
+
+/// An assertion that passes if its argument is `Error(_)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// Error(1) |> be_error
+/// // This assertion passes.
+/// ```
+///
+/// ```gleam
+/// Ok("a") |> be_error
+/// // This assertion fails.
+/// ```
+///
+pub fn be_error(value: Result(a, e)) -> Assertion {
+  case value {
+    Error(_) -> assertion.pass()
+    Ok(_) ->
+      assertion.fail_with_reason(assertion.AssertionFailed(
+        string.inspect(value),
+        "should be",
+        "Error(_)",
+      ))
+  }
+}
+
+/// An assertion that passes if the first argument is striclty lower
+/// than the other.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > 2 |> be_lower(than: 4)
+/// // This assertion passes.
+/// ```
+///
+/// ```gleam
+/// > 2 |> be_lower(than: 2)
+/// > 2 |> be_lower(than: 1)
+/// // These assertions fail.
+/// ```
+///
+pub fn be_lower(value: Int, than other: Int) -> Assertion {
+  "should be lower than"
+  |> compare(value, other, fn(n, m) { n < m }, int.to_string)
+}
+
+/// An assertion that passes if the first argument is lower or equal
+/// to the other.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > 2 |> be_lower_or_equal(to: 4)
+/// > 2 |> be_lower_or_equal(to: 2)
+/// // These assertions pass.
+/// ```
+///
+/// ```gleam
+/// > 2 |> be_lower_or_equal(to: 1)
+/// // This assertion fails.
+/// ```
+///
+pub fn be_lower_or_equal(value: Int, to other: Int) -> Assertion {
+  "should be lower or equal to"
+  |> compare(value, other, fn(n, m) { n <= m }, int.to_string)
+}
+
+/// An assertion that passes if the first argument is striclty greater
+/// than the other.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > 3 |> be_greater(than: 2)
+/// // This assertion passes.
+/// ```
+///
+/// ```gleam
+/// > 3 |> be_greater(than: 3)
+/// > 3 |> be_greater(than: 4)
+/// // These assertions fail.
+/// ```
+///
+pub fn be_greater(value: Int, than other: Int) -> Assertion {
+  "should be greater than"
+  |> compare(value, other, fn(n, m) { n > m }, int.to_string)
+}
+
+/// An assertion that passes if the first argument is greater
+/// or equal to the other.
+///
+/// ## Examples
+///
+/// ```gleam
+/// > 3 |> be_greater_or_equal(to: 2)
+/// > 3 |> be_greater_or_equal(to: 3)
+/// // These assertions pass.
+/// ```
+///
+/// ```gleam
+/// > 3 |> be_greater_or_equal(to: 4)
+/// // This assertion fails.
+/// ```
+///
+pub fn be_greater_or_equal(value: Int, to other: Int) -> Assertion {
+  "should be greater or equal to"
+  |> compare(value, other, fn(n, m) { n >= m }, int.to_string)
+}
+
+/// TODO: add a group of assertions to work on floating point numbers!
+fn compare(
+  asserted: String,
+  value: a,
+  other: a,
+  comparison: fn(a, a) -> Bool,
+  to_string: fn(a) -> String,
+) -> Assertion {
+  case comparison(value, other) {
+    True -> assertion.pass()
+    False ->
+      assertion.fail_with_reason(assertion.AssertionFailed(
+        to_string(value),
+        asserted,
+        to_string(other),
+      ))
   }
 }

--- a/src/galvanize/should.gleam
+++ b/src/galvanize/should.gleam
@@ -9,7 +9,7 @@
 ////
 //// This module exposes some basic functions used to make assertions
 //// and combine them.
-//// 
+////
 
 import gleam/int
 import gleam/string
@@ -254,18 +254,18 @@ fn compare(
 ///
 /// ```gleam
 /// > 1 |> pass_all([
-/// >   be_equal(to: 1),
-/// >   differ(from: 2),
-/// >   be_greater(than: 0),
+/// >   be_equal(_, to: 1),
+/// >   differ(_, from: 2),
+/// >   be_greater(_, than: 0),
 /// > ])
 /// // This assertion passes.
 /// ```
 ///
 /// ```gleam
 /// > 1 |> pass_all([
-/// >   be_equal(to: 1),
-/// >   differ(from: 1),
-/// >   be_greater(than: 0),
+/// >   be_equal(_, to: 1),
+/// >   differ(_, from: 1),
+/// >   be_greater(_, than: 0),
 /// > ])
 /// // This assertion fails since `differ(1, from: 1)` fails.
 /// ```
@@ -291,16 +291,16 @@ pub fn pass_all(subject: a, assertions: List(fn(a) -> Assertion)) -> Assertion {
 ///
 /// ```gleam
 /// > 1 |> pass_any([
-/// >   be_equal(to: 1),
-/// >   differ(from: 1),
+/// >   be_equal(_, to: 1),
+/// >   differ(_, from: 1),
 /// > ])
 /// // This assertion passes because `1 |> be_equal(to: 1)` passes.
 /// ```
 ///
 /// ```gleam
 /// > 1 |> pass_any([
-/// >   differ(from: 1),
-/// >   be_greater(than: 0),
+/// >   differ(_, from: 1),
+/// >   be_greater(_, than: 0),
 /// > ])
 /// // This assertion fails since all the assertions fail.
 /// ```

--- a/src/galvanize/should.gleam
+++ b/src/galvanize/should.gleam
@@ -24,17 +24,17 @@ import gleam/int
 ///
 /// ["a", "b", "c"]
 /// |> list.length
-/// |> equal(3)
+/// |> be_equal(to: 3)
 /// // This assertion passes.
 /// ```
 ///
 /// ```gleam
 /// Ok(1)
-/// |> equal(Error("a"))
+/// |> be_equal(to: Error("a"))
 /// // This assertion fails.
 /// ```
 ///
-pub fn equal(actual: a, expected: a) -> Assertion {
+pub fn be_equal(value: a, to expected: a) -> Assertion {
   // TODO: for now in case of equality failure the only reason is `Equality`
   // At the end it will just show the two strings side by side (maybe even
   // with sime kind of super simple diff).
@@ -50,11 +50,11 @@ pub fn equal(actual: a, expected: a) -> Assertion {
   //   inspect its type with `inspect` and use the appropriate reason based
   //   on that defaulting to the `Equality` reason for anything that does
   //   not require nothing more than a simple diff.
-  case actual == expected {
+  case value == expected {
     True -> assertion.pass()
     False ->
       assertion.fail_with_reason(assertion.EqualityAssertionFailed(
-        actual: string.inspect(actual),
+        actual: string.inspect(value),
         expected: string.inspect(expected),
       ))
   }
@@ -69,22 +69,22 @@ pub fn equal(actual: a, expected: a) -> Assertion {
 ///
 /// ["a", "b", "c"]
 /// |> list.length
-/// |> not_equal(2)
+/// |> differ(from: 2)
 /// // This assertion passes.
 /// ```
 ///
 /// ```gleam
 /// Ok(1)
-/// |> not_equal(Ok(1))
+/// |> differ(from: Ok(1))
 /// // This assertion fails.
 /// ```
 ///
-pub fn not_equal(one: a, other: a) -> Assertion {
-  case one != other {
+pub fn differ(value: a, from other: a) -> Assertion {
+  case value != other {
     True -> assertion.pass()
     False ->
       assertion.fail_with_reason(assertion.AssertionFailed(
-        string.inspect(one),
+        string.inspect(value),
         "should not equal",
         string.inspect(other),
       ))

--- a/src/galvanize/should.gleam
+++ b/src/galvanize/should.gleam
@@ -85,7 +85,7 @@ pub fn differ(value: a, from other: a) -> Assertion {
     False ->
       assertion.fail_with_reason(assertion.AssertionFailed(
         string.inspect(value),
-        "should not equal",
+        "should differ from",
         string.inspect(other),
       ))
   }

--- a/test/galvanize/assertion_test.gleam
+++ b/test/galvanize/assertion_test.gleam
@@ -1,0 +1,40 @@
+import galvanize/assertion
+import gleeunit/should
+
+pub fn pass_test() {
+  assertion.pass()
+  |> assertion.has_failed
+  |> should.equal(False)
+
+  assertion.pass()
+  |> assertion.to_result
+  |> should.be_ok
+}
+
+pub fn fail_test() {
+  let assertion = assertion.fail("reason")
+
+  assertion
+  |> assertion.has_failed
+  |> should.equal(True)
+
+  assertion
+  |> assertion.to_result
+  |> should.equal(Error(assertion.GenericFailure("reason")))
+}
+
+pub fn fail_with_reason_test() {
+  let reason = assertion.GenericFailure("fail")
+  let assertion = assertion.fail_with_reason(reason)
+
+  assertion
+  |> assertion.has_failed
+  |> should.equal(True)
+
+  assertion
+  |> assertion.to_result
+  |> should.equal(Error(reason))
+
+  assertion
+  |> should.equal(assertion.fail("fail"))
+}

--- a/test/galvanize/should_test.gleam
+++ b/test/galvanize/should_test.gleam
@@ -1,0 +1,127 @@
+import galvanize/should
+import galvanize/assertion.{Assertion}
+import gleeunit/should as glee_should
+
+pub fn should_equal_test() {
+  1
+  |> should.equal(1)
+  |> should_pass
+
+  [1, 2, 3]
+  |> should.equal([1, 2, 3])
+  |> should_pass
+
+  1
+  |> should.equal(2)
+  |> should_fail
+
+  [1, 2, 3]
+  |> should.equal([3, 2, 1])
+  |> should_fail
+}
+
+fn should_fail(assertion: Assertion) {
+  assertion
+  |> assertion.to_result
+  |> glee_should.be_error
+}
+
+fn should_pass(assertion: Assertion) {
+  assertion
+  |> assertion.to_result
+  |> glee_should.be_ok
+}
+
+pub fn should_not_equal_test() {
+  1
+  |> should.not_equal(2)
+  |> should_pass
+
+  1
+  |> should.not_equal(1)
+  |> should_fail
+
+  [1, 2, 3]
+  |> should.not_equal([3, 2, 1])
+  |> should_pass
+
+  [1, 2, 3]
+  |> should.not_equal([1, 2, 3])
+  |> should_fail
+}
+
+pub fn should_be_ok_test() {
+  Ok(1)
+  |> should.be_ok
+  |> should_pass
+
+  Error(1)
+  |> should.be_ok
+  |> should_fail
+}
+
+pub fn should_be_error_test() {
+  Error(1)
+  |> should.be_error
+  |> should_pass
+
+  Ok(1)
+  |> should.be_error
+  |> should_fail
+}
+
+pub fn should_be_lower_test() {
+  1
+  |> should.be_lower(than: 0)
+  |> should_fail
+
+  1
+  |> should.be_lower(than: 1)
+  |> should_fail
+
+  1
+  |> should.be_lower(than: 2)
+  |> should_pass
+}
+
+pub fn should_be_lower_or_equal_test() {
+  1
+  |> should.be_lower_or_equal(to: 0)
+  |> should_fail
+
+  1
+  |> should.be_lower_or_equal(to: 1)
+  |> should_pass
+
+  1
+  |> should.be_lower_or_equal(to: 2)
+  |> should_pass
+}
+
+pub fn should_be_greater_test() {
+  1
+  |> should.be_greater(than: 0)
+  |> should_pass
+
+  1
+  |> should.be_greater(than: 1)
+  |> should_fail
+
+  1
+  |> should.be_greater(than: 2)
+  |> should_fail
+}
+
+pub fn should_be_greater_or_equal_test() {
+  1
+  |> should.be_greater_or_equal(to: 0)
+  |> should_pass
+
+  1
+  |> should.be_greater_or_equal(to: 1)
+  |> should_pass
+
+  1
+  |> should.be_greater_or_equal(to: 2)
+  |> should_fail
+}

--- a/test/galvanize/should_test.gleam
+++ b/test/galvanize/should_test.gleam
@@ -125,3 +125,59 @@ pub fn should_be_greater_or_equal_test() {
   |> should.be_greater_or_equal(to: 2)
   |> should_fail
 }
+
+pub fn should_pass_all_test() {
+  1
+  |> should.pass_all([])
+  |> should_pass
+
+  1
+  |> should.pass_all([should.be_equal(_, to: 1)])
+  |> should_pass
+
+  1
+  |> should.pass_all([should.differ(_, from: 1)])
+  |> should_fail
+
+  1
+  |> should.pass_all([
+    should.be_equal(_, to: 1),
+    should.be_greater(_, than: 0),
+    should.be_lower_or_equal(_, to: 1),
+  ])
+  |> should_pass
+
+  1
+  |> should.pass_all([
+    should.be_equal(_, to: 1),
+    should.differ(_, from: 1),
+    fn(_) { panic },
+  ])
+  |> should_fail
+}
+
+pub fn should_pass_any_test() {
+  1
+  |> should.pass_any([])
+  |> should_pass
+
+  1
+  |> should.pass_any([should.be_equal(_, to: 1)])
+  |> should_pass
+
+  1
+  |> should.pass_any([should.differ(_, from: 1)])
+  |> should_fail
+
+  1
+  |> should.pass_any([
+    should.differ(_, from: 1),
+    should.be_equal(_, to: 1),
+    fn(_) { panic },
+  ])
+  |> should_pass
+
+  1
+  |> should.pass_any([should.differ(_, from: 1), should.be_greater(_, than: 2)])
+  |> should_fail
+}

--- a/test/galvanize/should_test.gleam
+++ b/test/galvanize/should_test.gleam
@@ -4,19 +4,19 @@ import gleeunit/should as glee_should
 
 pub fn should_equal_test() {
   1
-  |> should.equal(1)
+  |> should.be_equal(1)
   |> should_pass
 
   [1, 2, 3]
-  |> should.equal([1, 2, 3])
+  |> should.be_equal([1, 2, 3])
   |> should_pass
 
   1
-  |> should.equal(2)
+  |> should.be_equal(2)
   |> should_fail
 
   [1, 2, 3]
-  |> should.equal([3, 2, 1])
+  |> should.be_equal([3, 2, 1])
   |> should_fail
 }
 
@@ -32,21 +32,21 @@ fn should_pass(assertion: Assertion) {
   |> glee_should.be_ok
 }
 
-pub fn should_not_equal_test() {
+pub fn should_differ_test() {
   1
-  |> should.not_equal(2)
+  |> should.differ(from: 2)
   |> should_pass
 
   1
-  |> should.not_equal(1)
+  |> should.differ(from: 1)
   |> should_fail
 
   [1, 2, 3]
-  |> should.not_equal([3, 2, 1])
+  |> should.differ(from: [3, 2, 1])
   |> should_pass
 
   [1, 2, 3]
-  |> should.not_equal([1, 2, 3])
+  |> should.differ(from: [1, 2, 3])
   |> should_fail
 }
 

--- a/test/galvanize_test.gleam
+++ b/test/galvanize_test.gleam
@@ -1,21 +1,5 @@
-import galvanize.{add, run_seq, test, test_suite}
-import galvanize/should
+import gleeunit
 
 pub fn main() {
-  test_suite("Arithmetic")
-  |> add({
-    use <- test("One plus One")
-    1 + 1
-    |> should.equal(2)
-  })
-  |> add({
-    use <- test("Two minus one")
-    2 - 1
-    |> should.equal(1)
-  })
-  |> add({
-    use <- test("Should panic")
-    panic
-  })
-  |> run_seq
+  gleeunit.main()
 }


### PR DESCRIPTION
Right now `gleeunit` (and `glacier`) basic assertions - like `should.equal` - are functions that return `Nil` and fail with a `panic` or similar to signal the test's failure.

I'd rather go for a more structured approach that doesn't rely on panics and I've started investigating it. If you're curious you can look at Elm test's `Expect` module which is basically my inspiration for this PR.

Now an assertion like `should.equal` (which can be considered as the base building block of a test suite) returns a data structure `Assertion` that holds data about the test result; wether it passed or failed and the reason for the failure. This can allow any test runner to display information about the test more easily instead of relying on ffi to capture panics.

For example, an assertion like `2 |> should.be_greater(than: 3)` fails with the following `Assertion`:
```gleam
Fail(AssertionFailed("2", "should be greater", "3"))
```
That could be displayed nicely like Elm test does (or in any other way):
```
2
┬
│ should be greater than
v
3
```

I'm really curious to know your opinion @bcpeinhardt, let me know what you think!
Also the PR is still a WIP since it is missing some basic assertions:

- [x] something to combine multiple assertions into one (I've added `should.pass_all` and `should.pass_any`)
- [ ] something to work with floats
