### PR TITLE
Update runner to handle assertions

### DIFF
--- a/src/example.gleam
+++ b/src/example.gleam
@@ -1,0 +1,31 @@
+//// This module is just for demonstrating an example test suite written with galvanize.
+//// You can run it by running `gleam run -m example`
+
+import galvanize/should
+import galvanize.{add, run_seq, test, test_suite}
+
+pub fn main() {
+  test_suite("Arithmetic")
+  |> add(test(
+    "One plus one",
+    fn() {
+      1 + 1
+      |> should.be_equal(to: 2)
+    },
+  ))
+  |> add(test(
+    "Two minus one should be one",
+    fn() {
+      2 - 1
+      |> should.be_equal(to: 1)
+    },
+  ))
+  |> add(test(
+    "Two and two are different",
+    fn() {
+      2
+      |> should.differ(from: 2)
+    },
+  ))
+  |> run_seq
+}

--- a/src/galvanize.gleam
+++ b/src/galvanize.gleam
@@ -5,31 +5,26 @@ import colours
 import galvanize/assertion.{Assertion, Fail, Pass, reason_to_string}
 
 const passing_colour = colours.fgpalegreen4
-const failing_colour = colours.fgred3 
 
-/// A test is just a name and a function that takes no parameters and returns Nil
-/// The test passes if the function executes without panicking
-/// The test fails if the function panics
-pub type Test =
+const failing_colour = colours.fgred3
+
+type Test =
   #(String, fn() -> Assertion)
 
-/// A test suite has a name and a list of tests
-pub type TestSuite =
+type TestSuite =
   #(String, List(Test))
 
-/// A test can either pass or fail. If it failed, there 
-/// should be a reason
-pub type TestOutcome {
-  Passed
-  Failed(reason: String)
-}
-
-/// Convenience function for creating a test with use syntax
+/// Function for creating a test.
+/// 
+/// ## Example
+/// ```gleam
+/// use <- test("One plus one equals two")
+/// 1 + 1 |> should.be_equal(to: 2)
+/// ```
 pub fn test(name: String, test_func: fn() -> Assertion) -> Test {
   #(name, test_func)
 }
 
-/// Run a test by sending it to execute in a separate task
 fn run_test(test: Test) {
   let #(name, func) = test
   case
@@ -40,28 +35,32 @@ fn run_test(test: Test) {
       case ass {
         Pass -> {
           "Test: " <> name <> " passed"
-          |> passing_colour |> colours.italic
+          |> passing_colour
+          |> colours.italic
           |> io.println
         }
         Fail(reason) -> {
           "Test: " <> name <> " failed: " <> reason_to_string(reason)
-          |> failing_colour |> colours.italic
+          |> failing_colour
+          |> colours.italic
           |> io.println
         }
       }
     }
     Error(Timeout) ->
       "Test: " <> name <> " timed out!"
-      |> failing_colour |> colours.italic
+      |> failing_colour
+      |> colours.italic
       |> io.println
     Error(Exit(_)) ->
       "Test: " <> name <> " failed!"
-      |> failing_colour |> colours.italic
+      |> failing_colour
+      |> colours.italic
       |> io.println
   }
 }
 
-/// Run a list of tests sequentially
+/// Run a test suite sequentially.
 pub fn run_seq(test_suite: TestSuite) {
   let #(name, tests) = test_suite
   "Running Test Suite: " <> name
@@ -73,10 +72,12 @@ pub fn run_seq(test_suite: TestSuite) {
   }
 }
 
+/// Create a new test suite
 pub fn test_suite(name: String) -> TestSuite {
   #(name, [])
 }
 
+/// Add a test to the test suite
 pub fn add(test_suite: TestSuite, tst: Test) -> TestSuite {
   let #(name, tests) = test_suite
   #(name, [tst, ..tests])

--- a/src/galvanize/assertion.gleam
+++ b/src/galvanize/assertion.gleam
@@ -1,6 +1,6 @@
 /// Describes the result of a single test's comparison.
 ///
-pub opaque type Assertion {
+pub type Assertion {
   Pass
   Fail(Reason)
 }
@@ -11,6 +11,16 @@ pub type Reason {
   EqualityAssertionFailed(expected: String, actual: String)
   AssertionFailed(subject: String, asserted: String, object: String)
   GenericFailure(reason: String)
+}
+
+pub fn reason_to_string(reason: Reason) -> String {
+  case reason {
+    EqualityAssertionFailed(expected, actual) ->
+      "Expected: " <> expected <> ", Found: " <> actual
+    AssertionFailed(subject, asserted, object) ->
+      subject <> " " <> asserted <> " " <> object
+    GenericFailure(reason) -> reason
+  }
 }
 
 /// Turns an assertion into a `Result`.


### PR DESCRIPTION
I just updated the runner to handle assertions, fiddled with the colours, and added an example module. You can see how the test cases print by running `gleam run -m example`. You alright with this getting merged?